### PR TITLE
add receiver address for OrderRecord event

### DIFF
--- a/contracts/8/DexRouter.sol
+++ b/contracts/8/DexRouter.sol
@@ -398,6 +398,7 @@ contract DexRouter is
             fromToken,
             _baseRequest.toToken,
             tx.origin,
+            receiver
             _baseRequest.fromTokenAmount,
             returnAmount
         );

--- a/contracts/8/DexRouter.sol
+++ b/contracts/8/DexRouter.sol
@@ -394,11 +394,12 @@ contract DexRouter is
             "Min return not reached"
         );
 
+        // emit event
         emit OrderRecord(
             fromToken,
             _baseRequest.toToken,
             tx.origin,
-            receiver
+            receiver,
             _baseRequest.fromTokenAmount,
             returnAmount
         );

--- a/contracts/8/DexRouter.sol
+++ b/contracts/8/DexRouter.sol
@@ -394,7 +394,7 @@ contract DexRouter is
             "Min return not reached"
         );
 
-        // emit event
+        // 7. emit event
         emit OrderRecord(
             fromToken,
             _baseRequest.toToken,

--- a/contracts/8/UnxswapRouter.sol
+++ b/contracts/8/UnxswapRouter.sol
@@ -500,7 +500,8 @@ contract UnxswapRouter is CommonUtils {
             log1(
                 emptyPtr,
                 0xa0,
-                0x1bb43f2da90e35f7b0cf38521ca95a49e68eb42fac49924930a5bd73cdf7576c
+                0xfe793b6df82276a4e48bce23dda9cca20cac1aec78da1e85ebcdacf7b5db347a 
+                // keccak256("OrderRecord(address,address,address,address,uint256,uint256)")
             )
         }
     }

--- a/contracts/8/UnxswapRouter.sol
+++ b/contracts/8/UnxswapRouter.sol
@@ -495,6 +495,7 @@ contract UnxswapRouter is CommonUtils {
             mstore(emptyPtr, srcToken)
             mstore(add(emptyPtr, 0x20), toToken)
             mstore(add(emptyPtr, 0x40), origin())
+            mstore(add(emptyPtr, 0x40), receiver)
             mstore(add(emptyPtr, 0x60), amount)
             mstore(add(emptyPtr, 0x80), returnAmount)
             log1(

--- a/contracts/8/UnxswapRouter.sol
+++ b/contracts/8/UnxswapRouter.sol
@@ -492,15 +492,15 @@ contract UnxswapRouter is CommonUtils {
                 ) // "Min return not reached"
             }
             // emit event
-            mstore(emptyPtr, srcToken)
-            mstore(add(emptyPtr, 0x20), toToken)
-            mstore(add(emptyPtr, 0x40), origin())
-            mstore(add(emptyPtr, 0x40), receiver)
-            mstore(add(emptyPtr, 0x60), amount)
-            mstore(add(emptyPtr, 0x80), returnAmount)
+            mstore(emptyPtr,              srcToken)       // [0x00 -> 0x1F]  fromToken
+            mstore(add(emptyPtr, 0x20),   toToken)        // [0x20 -> 0x3F]  toToken
+            mstore(add(emptyPtr, 0x40),   origin())       // [0x40 -> 0x5F]  sender
+            mstore(add(emptyPtr, 0x60),   receiver)       // [0x60 -> 0x7F]  receiver
+            mstore(add(emptyPtr, 0x80),   amount)         // [0x80 -> 0x9F]  fromAmount
+            mstore(add(emptyPtr, 0xA0),   returnAmount)   // [0xA0 -> 0xBF]  returnAmount
             log1(
                 emptyPtr,
-                0xa0,
+                0xc0, // 6 × 32 bytes = 0xC0
                 0xfe793b6df82276a4e48bce23dda9cca20cac1aec78da1e85ebcdacf7b5db347a 
                 // keccak256("OrderRecord(address,address,address,address,uint256,uint256)")
             )

--- a/contracts/8/UnxswapV3Router.sol
+++ b/contracts/8/UnxswapV3Router.sol
@@ -261,7 +261,8 @@ contract UnxswapV3Router is IUniswapV3SwapCallback, CommonUtils {
                 log1(
                     0,
                     160,
-                    0x1bb43f2da90e35f7b0cf38521ca95a49e68eb42fac49924930a5bd73cdf7576c
+                    0xfe793b6df82276a4e48bce23dda9cca20cac1aec78da1e85ebcdacf7b5db347a
+                    // keccak256("OrderRecord(address,address,address,address,uint256,uint256)")
                 )
                 mstore(0x40, freePtr)
             }

--- a/contracts/8/UnxswapV3Router.sol
+++ b/contracts/8/UnxswapV3Router.sol
@@ -256,11 +256,12 @@ contract UnxswapV3Router is IUniswapV3SwapCallback, CommonUtils {
                 mstore(0, srcToken)
                 mstore(32, toToken)
                 mstore(64, origin())
-                // mstore(96, _initAmount) //avoid stack too deep, since i mstore the initAmount to 96, so no need to re-mstore it
-                mstore(128, _returnAmount)
+                mstore(96, receiver)
+                // mstore(128, _initAmount) //avoid stack too deep, since i mstore the initAmount to 128, so no need to re-mstore it
+                mstore(160, _returnAmount)
                 log1(
                     0,
-                    160,
+                    192,
                     0xfe793b6df82276a4e48bce23dda9cca20cac1aec78da1e85ebcdacf7b5db347a
                     // keccak256("OrderRecord(address,address,address,address,uint256,uint256)")
                 )
@@ -291,7 +292,7 @@ contract UnxswapV3Router is IUniswapV3SwapCallback, CommonUtils {
                 }
             }
 
-            mstore(96, amount) // 96 is not override by _makeSwap, since it only use freePtr memory, and it is not override by unWrapWeth ethier
+            mstore(128, amount) // 128 is not override by _makeSwap, since it only use freePtr memory, and it is not override by unWrapWeth ethier
             for {
                 let i := firstPoolStart
             } lt(i, lastPoolStart) {

--- a/contracts/8/libraries/CommonUtils.sol
+++ b/contracts/8/libraries/CommonUtils.sol
@@ -77,6 +77,7 @@ abstract contract CommonUtils {
         address fromToken,
         address toToken,
         address sender,
+        address receiver,
         uint256 fromAmount,
         uint256 returnAmount
     );

--- a/contracts/8/libraries/WrapETHSwap.sol
+++ b/contracts/8/libraries/WrapETHSwap.sol
@@ -32,6 +32,6 @@ abstract contract WrapETHSwap is CommonUtils {
       SafeERC20.safeTransfer(IERC20(_WETH), msg.sender, amount);
     }
     emit SwapOrderId(orderId);
-    emit OrderRecord(reversed ? _WETH : _ETH, reversed ? _ETH: _WETH, msg.sender, amount, amount);
+    emit OrderRecord(reversed ? _WETH : _ETH, reversed ? _ETH: _WETH, msg.sender, msg.sender, amount, amount);
   }
 }


### PR DESCRIPTION
## What

Add the receiver address field to the OrderRecord event.

## Why

Currently, when a swap occurs, an `OrderRecord` event is emitted. However, the event does not include the `receiver` address, making it difficult to trace or verify the recipient of the swap. This addition ensures the event captures complete transaction details, improving transparency and debugging capabilities.


## Related Issue
Fixes #7

## PR Checklist

- [x] Tests
  - [x] Doesn't apply
- [x] Documentation
  - [x] Updated inline comments